### PR TITLE
Comparing changes

### DIFF
--- a/src/components/ble/SimpleWeatherService.cpp
+++ b/src/components/ble/SimpleWeatherService.cpp
@@ -1,21 +1,3 @@
-/*  Copyright (C) 2023 Jean-François Milants
-
-    This file is part of InfiniTime.
-
-    InfiniTime is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published
-    by the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    InfiniTime is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <https://www.gnu.org/licenses/>.
-*/
-
 #include "components/ble/SimpleWeatherService.h"
 
 #include <algorithm>
@@ -80,7 +62,7 @@ int WeatherCallback(uint16_t /*connHandle*/, uint16_t /*attrHandle*/, struct ble
   return static_cast<Pinetime::Controllers::SimpleWeatherService*>(arg)->OnCommand(ctxt);
 }
 
-SimpleWeatherService::SimpleWeatherService(DateTime& dateTimeController) : dateTimeController(dateTimeController) {
+SimpleWeatherService::SimpleWeatherService(const DateTime& dateTimeController) : dateTimeController(dateTimeController) {
 }
 
 void SimpleWeatherService::Init() {
@@ -127,7 +109,7 @@ int SimpleWeatherService::OnCommand(struct ble_gatt_access_ctxt* ctxt) {
 
 std::optional<SimpleWeatherService::CurrentWeather> SimpleWeatherService::Current() const {
   if (currentWeather) {
-    auto currentTime = dateTimeController.CurrentDateTime().time_since_epoch();
+    auto currentTime = dateTimeController.UTCDateTime().time_since_epoch();
     auto weatherTpSecond = std::chrono::seconds {currentWeather->timestamp};
     auto weatherTp = std::chrono::duration_cast<std::chrono::seconds>(weatherTpSecond);
     auto delta = currentTime - weatherTp;
@@ -141,7 +123,7 @@ std::optional<SimpleWeatherService::CurrentWeather> SimpleWeatherService::Curren
 
 std::optional<SimpleWeatherService::Forecast> SimpleWeatherService::GetForecast() const {
   if (forecast) {
-    auto currentTime = dateTimeController.CurrentDateTime().time_since_epoch();
+    auto currentTime = dateTimeController.UTCDateTime().time_since_epoch();
     auto weatherTpSecond = std::chrono::seconds {forecast->timestamp};
     auto weatherTp = std::chrono::duration_cast<std::chrono::seconds>(weatherTpSecond);
     auto delta = currentTime - weatherTp;
@@ -157,17 +139,4 @@ bool SimpleWeatherService::CurrentWeather::operator==(const SimpleWeatherService
   return this->iconId == other.iconId && this->temperature == other.temperature && this->timestamp == other.timestamp &&
          this->maxTemperature == other.maxTemperature && this->minTemperature == other.maxTemperature &&
          std::strcmp(this->location.data(), other.location.data()) == 0;
-}
-
-bool SimpleWeatherService::Forecast::Day::operator==(const SimpleWeatherService::Forecast::Day& other) const {
-  return this->iconId == other.iconId && this->maxTemperature == other.maxTemperature && this->minTemperature == other.maxTemperature;
-}
-
-bool SimpleWeatherService::Forecast::operator==(const SimpleWeatherService::Forecast& other) const {
-  for (int i = 0; i < this->nbDays; i++) {
-    if (this->days[i] != other.days[i]) {
-      return false;
-    }
-  }
-  return this->timestamp == other.timestamp && this->nbDays == other.nbDays;
 }

--- a/src/displayapp/screens/Weather.cpp
+++ b/src/displayapp/screens/Weather.cpp
@@ -120,6 +120,7 @@ void Weather::Refresh() {
   if (currentWeather.IsUpdated()) {
     auto optCurrentWeather = currentWeather.Get();
     if (optCurrentWeather) {
+      uint32_t currentTimestamp = GetCurrentTimestamp();
       int16_t temp = optCurrentWeather->temperature;
       int16_t minTemp = optCurrentWeather->minTemperature;
       int16_t maxTemp = optCurrentWeather->maxTemperature;
@@ -136,6 +137,9 @@ void Weather::Refresh() {
       lv_label_set_text_fmt(temperature, "%d°%c", RoundTemperature(temp), tempUnit);
       lv_label_set_text_fmt(minTemperature, "%d°", RoundTemperature(minTemp));
       lv_label_set_text_fmt(maxTemperature, "%d°", RoundTemperature(maxTemp));
+      uint32_t timeDifference = currentTimestamp - lastUpdateTimestamp;
+      lv_label_set_text_fmt(updateTimeLabel, "Updated %d seconds ago", timeDifference);
+      lastUpdateTimestamp = currentTimestamp;
     } else {
       lv_label_set_text(icon, "");
       lv_label_set_text(condition, "");
@@ -144,7 +148,12 @@ void Weather::Refresh() {
       lv_label_set_text(minTemperature, "");
       lv_label_set_text(maxTemperature, "");
     }
-  }
+  }else {
+      uint32_t currentTimestamp = GetCurrentTimestamp();
+      uint32_t timeDifference = currentTimestamp - lastUpdateTimestamp;
+      lv_label_set_text_fmt(updateTimeLabel, "Updated %d seconds ago", timeDifference);
+    }
+}
 
   currentForecast = weatherService.GetForecast();
   if (currentForecast.IsUpdated()) {


### PR DESCRIPTION
Fix #2 
获取当前时间戳：在调用天气服务获取当前天气数据后，记录当前时间戳。
计算时间差：根据上次更新的时间戳和当前时间戳，计算自上次更新以来的时间差（以秒为单位）。
更新时间显示：使用 lv_label_set_text 将时间差显示在 UI 上。